### PR TITLE
Adding prisma generate command to entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,5 +16,8 @@ done
 # Run Prisma db push
 npx prisma db push
 
+# Run Prisma generate
+SKIP_PRISMA_VERSION_CHECK=true npx prisma generate
+
 # Start the application
 yarn start


### PR DESCRIPTION
I'm not sure this is the best fix, but I had to add this to `entrypoint.sh`:

`SKIP_PRISMA_VERSION_CHECK=true npx prisma generate`

As I found outlined here:

https://prisma.typegraphql.com/docs/basics/prisma-version

Running it on my own machine was necessary to get the Typescript compiler happy about this part in `graph.ts`:

```typescript
import {
  resolvers,
  applyResolversEnhanceMap,
  ResolversEnhanceMap,
} from "@generated/type-graphql";
```

Since it couldn't find `@generated/type-graphql` without it. But that doesn't carry over to the Docker container even after running a `docker-compose build` command, so it needed to be part of the build process.

Let me know if that's helpful or if you need any more info. Thanks!